### PR TITLE
feat(dev-server): several improvements to dev-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-broadcast"
@@ -339,9 +339,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -349,14 +349,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -843,9 +844,9 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "defmt"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
@@ -853,12 +854,11 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
 dependencies = [
  "defmt-parser",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1409,7 +1409,7 @@ dependencies = [
  "ipnet",
  "jni",
  "once_cell",
- "rand 0.10.1",
+ "rand 0.10.2",
  "thiserror",
  "tinyvec",
  "tracing",
@@ -1439,9 +1439,9 @@ checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -1585,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "inotify-sys"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+checksum = "9ea94e891b3606826e9c998be69ddca42247dad8ad50b1649a5cb7e1c9ae06fd"
 dependencies = [
  "libc",
 ]
@@ -1646,9 +1646,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
 dependencies = [
  "defmt",
  "jiff-static",
@@ -1660,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2733,9 +2733,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rancor"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+checksum = "daff8b7b3ccf5f7ba270b3e7a0a4d4c701c5797e38dec27c7e2c3dbb830fed1c"
 dependencies = [
  "ptr_meta",
 ]
@@ -2752,9 +2752,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "rand_core 0.10.1",
@@ -2863,9 +2863,9 @@ dependencies = [
 
 [[package]]
 name = "rend"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
 
 [[package]]
 name = "ring"
@@ -2883,9 +2883,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytes",
  "hashbrown 0.17.1",
@@ -2901,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2938,9 +2938,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3002,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3557,9 +3557,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "libc",
@@ -3579,9 +3579,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3745,6 +3745,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "shlex",
  "signal-hook",
  "size",
  "trillium",
@@ -3769,6 +3770,7 @@ dependencies = [
  "trillium-smol",
  "trillium-static",
  "trillium-websockets",
+ "url",
 ]
 
 [[package]]
@@ -4561,9 +4563,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+checksum = "4d93c89cdc2d3a63c3ec48ffe926931bdc069eafa8e4402fe6d8f790c9d1e576"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ dev-server = [
         "dep:signal-hook",
         "dep:libc",
         "dep:colored",
+        "dep:shlex",
+        "dep:url",
 ]
 client = [
   "dep:async-fs",
@@ -132,7 +134,7 @@ async-fs = { version = "2.2.0", optional = true }
 async-global-executor = "3.1.0"
 async-io = { version = "2.6.0", optional = true }
 blocking = { version = "1.6.2", optional = true }
-env_logger = "0.11.10"
+env_logger = "0.11.11"
 futures-lite = { version = "2.6.1", optional = true }
 log = "0.4.33"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
@@ -141,7 +143,7 @@ serde_json = { version = "1.0.150", optional = true }
 trillium = { version = "1.3.0", optional = true}
 trillium-native-tls = { version = "0.6.3", optional = true }
 trillium-rustls = { version = "0.11.3", optional = true }
-trillium-proxy = { version = "0.8.1", optional = true }
+trillium-proxy = { version = "0.8.2", optional = true }
 trillium-router = { version = "0.5.2", optional = true }
 trillium-static = { version = "0.6.1", features = [
         "smol",
@@ -150,7 +152,7 @@ trillium-websockets = { version = "0.8.2", features = [
         "json",
 ], optional = true }
 trillium-smol = { version = "0.7.0" }
-trillium-client = { version = "0.9.7", features = [
+trillium-client = { version = "0.9.8", features = [
         "sonic-rs", "hickory", "sse"
 ], optional = true }
 trillium-client-retry = { version = "0.0.1", optional = true }
@@ -168,7 +170,7 @@ trillium-compression = { version = "0.3.2", optional = true }
 trillium-ratelimit = { version = "0.0.0", optional = true }
 
 hdrhistogram = { version = "7.5.4", optional = true }
-indicatif = { version = "0.18.4", optional = true }
+indicatif = { version = "0.18.6", optional = true }
 humantime = { version = "2.3.0", optional = true }
 async-channel = { version = "2.5.0", optional = true }
 fastrand = { version = "2.4.1", optional = true }
@@ -184,6 +186,7 @@ size = { version = "0.5.0", optional = true }
 percent-encoding = { version = "2.3.2", optional = true }
 querystrong = { version = "0.4.0", optional = true }
 async-broadcast = { version = "0.7.2", optional = true }
+url = { version = "2.5", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = { version = "0.4.4", optional = true }
@@ -193,6 +196,7 @@ nix = { version = "0.31.3", default-features = false, features = [
         "process",
 ], optional = true }
 notify = { version = "8.2.0", optional = true }
+shlex = { version = "2.0.1", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 trillium-openssl = { version = "0.2", features = ["vendored"], optional = true }

--- a/README.md
+++ b/README.md
@@ -375,11 +375,13 @@ your app on a private port behind the proxy, passing it through as `PORT`. Use
 
 In a workspace it watches the crate it builds **plus the workspace-local crates
 it depends on**, so editing a path-dependency library reloads the app using it.
-Select what to build with cargo's own flags after a `--`:
+Select what to build with cargo's own flags via `--build-args`, and pass any
+runtime arguments your binary needs (a subcommand, a flag) with `--run-args`:
 
 ```sh
-trillium dev-server -- -p my-app --features dev
+trillium dev-server --build-args "-p my-app --features dev"
 trillium dev-server --example hello-world
+trillium dev-server --build-args "-p my-app" --run-args serve
 ```
 
 When a build fails, the errors render as an overlay in the browser (the previous

--- a/docs/guide/dev-server.md
+++ b/docs/guide/dev-server.md
@@ -77,12 +77,12 @@ to.
 ## Selecting what to build
 
 The dev server learns which binary to run from the build itself — whatever
-`cargo build` produces is what it launches. Pass cargo's own selection flags
-after a `--` and it all just works:
+`cargo build` produces is what it launches. Hand cargo's own selection flags to
+`--build-args`, as a single shell-quoted string, and it all just works:
 
 ```sh
-trillium dev-server -- -p my-crate
-trillium dev-server -- --bin worker --features dev
+trillium dev-server --build-args "-p my-crate"
+trillium dev-server --build-args "--bin worker --features dev"
 ```
 
 `--example` and `--release` are first-class (the example also adds `examples/`
@@ -92,6 +92,22 @@ to the watch set; release disables the dev build speedups described below):
 trillium dev-server --example hello-world
 trillium dev-server --release
 ```
+
+## Passing arguments to your app
+
+Some binaries need a subcommand or a runtime flag before they start serving —
+for example an app whose first argument is `serve`. Hand those to `--run-args`;
+they're passed to your binary on **every** start, including after each rebuild:
+
+```sh
+trillium dev-server --run-args serve
+trillium dev-server --build-args "-p my-app" --run-args "serve --verbose"
+```
+
+Both `--build-args` and `--run-args` take one shell-quoted string, split the way
+a shell would — so quotes and spaces survive, e.g. a config path with a space in
+it. Each flag can be repeated, appending to the list. Build args go to `cargo
+build`; run args go to the binary it produces.
 
 ## What gets watched
 
@@ -104,7 +120,7 @@ Add more directories (templates, assets, a crate outside the dependency graph)
 with `-w`/`--watch`; they're watched *in addition* to the default:
 
 ```sh
-trillium dev-server -- -p web --watch ./templates --watch ./assets
+trillium dev-server --build-args "-p web" --watch ./templates --watch ./assets
 ```
 
 Filesystem events are debounced, so saving several files at once triggers a
@@ -180,25 +196,24 @@ when the app comes up on its private port.
 ## Full flag reference
 
 ```
-trillium dev-server [OPTIONS] [-- <CARGO_ARGS>...]
-
-Arguments:
-  [CARGO_ARGS]...  extra arguments forwarded to `cargo build`, after a `--`
+trillium dev-server [OPTIONS]
 
 Options:
-  -o, --host <HOST>          [env: HOST=]       [default: localhost]
-  -p, --port <PORT>          [env: PORT=]       [default: 8080]
-  -w, --watch <WATCH>        extra dirs to watch (repeatable, added to default)
+  -o, --host <HOST>              [env: HOST=]       [default: localhost]
+  -p, --port <PORT>              [env: PORT=]       [default: 8080]
+  -w, --watch <WATCH>            extra dirs to watch (repeatable, added to default)
   -c, --cwd <CWD>
   -r, --release
   -e, --example <EXAMPLE>
-      --app-port <APP_PORT>  [env: APP_PORT=]   (use when the app hardcodes its port)
-      --app-host <APP_HOST>  [default: localhost]
-      --no-fast              disable dev build speedups
-      --editor <EDITOR>      [env: EDITOR=]     (also falls back to $VISUAL)
-  -s, --signal <SIGNAL>      [default: SIGTERM]
+      --app-port <APP_PORT>      [env: APP_PORT=]   (use when the app hardcodes its port)
+      --app-host <APP_HOST>      [default: localhost]
+      --no-fast                  disable dev build speedups
+      --editor <EDITOR>          [env: EDITOR=]     (also falls back to $VISUAL)
+  -s, --signal <SIGNAL>          [default: SIGTERM]
   -v, --verbose...
   -q, --quiet...
+      --build-args <BUILD_ARGS>  cargo build selection flags (shell-quoted, repeatable)
+      --run-args <RUN_ARGS>      args passed to your app on every start (shell-quoted, repeatable)
   -h, --help
 ```
 

--- a/src/dev_server.rs
+++ b/src/dev_server.rs
@@ -9,7 +9,7 @@ use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
 use signal_hook::{consts::signal::SIGHUP, iterator::Signals};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     env,
     fmt::Display,
     io::{self, Write},
@@ -18,11 +18,57 @@ use std::{
     process::{Child, Command, Stdio},
     sync::{
         Arc, Mutex,
+        atomic::{AtomicU16, Ordering},
         mpsc::{self, RecvTimeoutError},
     },
     thread,
     time::{Duration, Instant},
 };
+use trillium::Conn;
+use trillium_proxy::upstream::UpstreamSelector;
+use url::Url;
+
+/// The upstream the proxy forwards to, with a port that's updated on each
+/// (re)spawn so we can rotate ports between rebuilds without dropping the old
+/// child's in-flight connections. A port of `0` is the "no app yet" sentinel:
+/// the app hasn't come up for the first time, so there's nothing to proxy to
+/// and the readiness gate serves a "starting up" page instead.
+#[derive(Debug, Clone)]
+struct DynamicUpstream {
+    host: String,
+    port: Arc<AtomicU16>,
+}
+
+impl DynamicUpstream {
+    fn new(host: String) -> Self {
+        Self {
+            host,
+            port: Arc::new(AtomicU16::new(0)),
+        }
+    }
+
+    fn set_port(&self, port: u16) {
+        self.port.store(port, Ordering::Relaxed);
+    }
+
+    /// Whether the app has come up at least once and can be proxied to. Until
+    /// then (port 0) there's no upstream and we serve the "starting up" page.
+    fn is_ready(&self) -> bool {
+        self.port.load(Ordering::Relaxed) != 0
+    }
+}
+
+impl UpstreamSelector for DynamicUpstream {
+    fn determine_upstream(&self, _conn: &mut Conn) -> Option<Url> {
+        let port = self.port.load(Ordering::Relaxed);
+        // `None` here makes the proxy 502; the readiness gate ahead of it should
+        // have already served the "starting up" page, so this is just a guard.
+        if port == 0 {
+            return None;
+        }
+        format!("http://{}:{port}", self.host).parse().ok()
+    }
+}
 
 #[derive(Parser, Debug)]
 pub struct DevServer {
@@ -90,16 +136,29 @@ pub struct DevServer {
     #[command(flatten)]
     verbose: Verbosity<InfoLevel>,
 
-    /// Extra arguments forwarded to `cargo build`, after a `--`
+    /// Arguments for `cargo build`, to select what gets built
     ///
-    /// Use this to select what gets built — cargo resolves the binary, so the
-    /// dev server runs whatever it produces.
+    /// A single shell-quoted string, split like a shell would (repeatable; each
+    /// occurrence is appended). Cargo resolves the binary, so the dev server
+    /// runs whatever it produces.
     ///
     /// Examples:
-    ///    `trillium dev-server -- -p my-crate`
-    ///    `trillium dev-server -- --bin worker --features dev`
-    #[arg(last = true, verbatim_doc_comment)]
-    cargo_args: Vec<String>,
+    ///    `--build-args "-p my-crate"`
+    ///    `--build-args "--bin worker --features dev"`
+    #[arg(long, verbatim_doc_comment, allow_hyphen_values = true)]
+    build_args: Vec<String>,
+
+    /// Arguments passed to your app every time it starts
+    ///
+    /// A single shell-quoted string, split like a shell would (repeatable). Use
+    /// this when your binary needs a subcommand or runtime flags before it does
+    /// its thing — e.g. an app whose first argument selects `serve`.
+    ///
+    /// Examples:
+    ///    `--run-args serve`
+    ///    `--run-args "serve --verbose"`
+    #[arg(long, verbatim_doc_comment, allow_hyphen_values = true)]
+    run_args: Vec<String>,
 }
 
 /// Events broadcast to connected browsers over the dev-server websocket.
@@ -226,9 +285,15 @@ impl DevServer {
             .canonicalize()
             .unwrap_or_else(|e| die(format!("{}: {e}", cwd.display())));
 
+        // `--build-args`/`--run-args` each take a shell-quoted string; split them
+        // the way a shell would so quoting works as written. Build args select
+        // what cargo compiles; run args are handed to the app on every start.
+        let build_args = shell_split("--build-args", &self.build_args);
+        let app_args = shell_split("--run-args", &self.run_args);
+
         // The dev server adopts the user's public HOST/PORT; the app is moved
-        // onto a private port (auto-allocated unless --app-port pins it).
-        let upstream_port = self.app_port.unwrap_or_else(free_port);
+        // onto a private port, chosen per-spawn (a fresh one each rebuild unless
+        // --app-port pins it), so nothing is allocated up front here.
 
         // Build command (reused for every rebuild). We ask cargo for JSON so it
         // tells us exactly which binary it produced and gives us structured
@@ -236,24 +301,29 @@ impl DevServer {
         let mut build = Command::new("cargo");
         build
             .current_dir(&cwd)
-            .args(["build", "--message-format=json-diagnostic-rendered-ansi"]);
+            .args(["build", "--message-format=json-diagnostic-rendered-ansi"])
+            // Let cargo's human-readable side — `Compiling …`, the progress bar,
+            // the `Finished`/error summary — stream straight to our terminal, so a
+            // slow rebuild visibly *does* something instead of hanging silently.
+            // stdout stays piped: it's the JSON we parse for diagnostics and the
+            // produced binary, not something to show a human.
+            .stderr(Stdio::inherit());
         if self.release {
             build.arg("--release");
         }
         if let Some(example) = &self.example {
             build.args(["--example", example]);
         }
-        build.args(&self.cargo_args);
+        build.args(&build_args);
         if !self.no_fast && !self.release {
             apply_fast_build(&mut build);
         }
 
         // Watch scope is small by default: the src of the crate cargo will
         // build (resolved from `-p`/the workspace), plus anything the user adds.
-        let watches =
-            resolve_watch_dirs(&cwd, &self.cargo_args, self.example.is_some(), &self.watch);
+        let watches = resolve_watch_dirs(&cwd, &build_args, self.example.is_some(), &self.watch);
 
-        print_banner(&self, upstream_port, &watches);
+        print_banner(&self, &watches);
 
         let (tx, rx) = mpsc::channel::<()>();
         let (mut broadcast_tx, broadcast_rx) = async_broadcast::broadcast::<Event>(16);
@@ -290,6 +360,10 @@ impl DevServer {
         let open_targets = Arc::new(Mutex::new(Vec::new()));
         let status = Arc::new(Mutex::new(None));
 
+        // Create a shared upstream selector that can be updated on each rebuild.
+        // It starts "not ready" (port 0) until the first spawn comes up.
+        let upstream = DynamicUpstream::new(self.app_host.clone());
+
         // Supervisor: owns the child process, builds, and restarts.
         {
             let broadcaster = broadcast_tx.clone();
@@ -297,6 +371,8 @@ impl DevServer {
             let signal = self.signal;
             let open_targets = open_targets.clone();
             let status = status.clone();
+            let pinned_port = self.app_port;
+            let upstream = upstream.clone();
             thread::spawn(move || {
                 Supervisor {
                     rx,
@@ -305,7 +381,9 @@ impl DevServer {
                     cwd,
                     signal,
                     app_host,
-                    upstream_port,
+                    pinned_port,
+                    upstream,
+                    app_args,
                     exe: None,
                     child: None,
                     open_targets,
@@ -316,7 +394,6 @@ impl DevServer {
         }
 
         let editor = self.editor.clone().or_else(|| env::var("VISUAL").ok());
-        let upstream = format!("http://{}:{}", self.app_host, upstream_port);
         proxy_app::run(
             self.host.clone(),
             self.port,
@@ -337,7 +414,12 @@ struct Supervisor {
     cwd: PathBuf,
     signal: Signal,
     app_host: String,
-    upstream_port: u16,
+    /// Port for the app; fixed if --app-port was given, otherwise we rotate for each spawn.
+    pinned_port: Option<u16>,
+    /// Shared upstream selector for the proxy to dynamically determine the app port.
+    upstream: DynamicUpstream,
+    /// Args forwarded to the app on every start (from `--run-args`).
+    app_args: Vec<String>,
     /// The executable cargo produced for the most recent successful build.
     exe: Option<PathBuf>,
     child: Option<Child>,
@@ -425,17 +507,26 @@ impl Supervisor {
         }
 
         if !output.status.success() {
-            // A failure with no compiler diagnostics is cargo itself complaining
-            // (e.g. an unknown `-p`). Surface its stderr as a single diagnostic.
-            if terminal.trim().is_empty() {
-                terminal = String::from_utf8_lossy(&output.stderr).into_owned();
+            // cargo's progress and top-level error summary already streamed live
+            // to the terminal (stderr is inherited). The per-error diagnostics,
+            // though, only arrived as JSON on stdout — echo their rendered form so
+            // the terminal actually shows *what* failed, not just "could not
+            // compile due to N errors".
+            if !terminal.trim().is_empty() {
+                io::stderr().write_all(terminal.as_bytes()).ok();
             }
-            io::stderr().write_all(terminal.as_bytes()).ok();
             if diagnostics.is_empty() {
+                // No structured diagnostics: cargo itself refused (e.g. an unknown
+                // `-p`). That message already went to the terminal, but the browser
+                // overlay has nothing to render, so send it there.
                 diagnostics.push(Diagnostic {
                     level: "error".into(),
                     message: "build failed".into(),
-                    rendered: ansi_to_html::convert(&terminal).unwrap_or(terminal),
+                    rendered: if terminal.trim().is_empty() {
+                        "build failed — see the dev-server terminal for details".into()
+                    } else {
+                        ansi_to_html::convert(&terminal).unwrap_or(terminal)
+                    },
                     file: None,
                     line: None,
                     column: None,
@@ -450,7 +541,8 @@ impl Supervisor {
 
         if executables.len() > 1 {
             log::warn!(
-                "build produced {} binaries; running the last. Use `-- --bin <name>` to pick one.",
+                "build produced {} binaries; running the last. Use `--build-args \"--bin \
+                 <name>\"` to pick one.",
                 executables.len()
             );
         }
@@ -464,43 +556,108 @@ impl Supervisor {
             None => {
                 log::error!(
                     "build succeeded but produced no runnable binary — is this a binary crate? \
-                     try `--example <name>` or `-- --bin <name>`"
+                     try `--example <name>` or `--build-args \"--bin <name>\"`"
                 );
                 false
             }
         }
     }
 
-    fn spawn(&mut self) {
-        let Some(exe) = self.exe.clone() else { return };
+    /// Start the app on its port (freshly allocated unless `--app-port` pinned
+    /// it), wait for it to come up, and only then point the proxy at it — so any
+    /// previous child keeps serving until the new one is ready. Returns true if
+    /// the process was started (the caller may then retire the old child).
+    fn spawn(&mut self) -> bool {
+        let Some(exe) = self.exe.clone() else {
+            return false;
+        };
+
+        // A fresh port per spawn (unless pinned) lets the outgoing child keep
+        // serving on its old port while this one starts up on the new one.
+        let port = self.pinned_port.unwrap_or_else(free_port);
+
         // A fresh Command each time: the executable path can change between
         // builds (e.g. debug ↔ release, or a different selected target).
         let mut command = Command::new(exe);
         command
+            .args(&self.app_args)
             .current_dir(&self.cwd)
-            .env("PORT", self.upstream_port.to_string())
+            .env("PORT", port.to_string())
             .env("HOST", &self.app_host)
             .env("TRILLIUM_CLI_DEV_SERVER", "1");
+
         match command.spawn() {
             Ok(child) => {
                 self.child = Some(child);
-                wait_until_listening(&self.app_host, self.upstream_port);
+                let listening = wait_until_listening(&self.app_host, port);
+                // Flip the proxy over only now: while this child was starting
+                // up, any previous child kept receiving traffic on its own port.
+                self.upstream.set_port(port);
+                if listening {
+                    println!(
+                        "{}",
+                        format!("  app listening on {}:{}", self.app_host, port).green()
+                    );
+                } else {
+                    println!(
+                        "  {} app failed to bind to {}:{}",
+                        "warning:".yellow(),
+                        self.app_host,
+                        port
+                    );
+                }
+                true
             }
-            Err(e) => log::error!("failed to start app: {e}"),
+            Err(e) => {
+                println!("  {} failed to start app: {}", "error:".red().bold(), e);
+                false
+            }
         }
     }
 
-    /// Ask the running child to exit, then wait for it.
+    /// Fully retire the current child, blocking until it's gone. Used on the
+    /// fixed-port path, where the new child can't bind until this one lets go.
     fn stop(&mut self) {
-        if let Some(mut child) = self.child.take() {
-            let _ = signal::kill(Pid::from_raw(child.id() as i32), self.signal);
-            let _ = child.wait();
+        if let Some(child) = self.child.take() {
+            reap_child(child, self.signal);
+        }
+    }
+
+    /// Swap in the freshly-built app. With a rotating port the new child comes
+    /// up on a fresh port and takes over the instant it's listening, while the
+    /// previous child keeps draining its in-flight requests on the old port in
+    /// the background — a true hot-deploy with no gap. With a pinned port the
+    /// two can't coexist on the same port, so the old child is fully retired
+    /// first (blocking for the length of its drain).
+    fn hot_swap(&mut self) {
+        if self.pinned_port.is_some() {
+            self.stop();
+            if self.spawn() {
+                self.broadcast(Event::Restarted);
+            }
+            return;
+        }
+
+        // Keep the old child alive and serving until the new one is listening;
+        // `spawn` flips the proxy over only once that happens.
+        let old = self.child.take();
+        if self.spawn() {
+            if let Some(old) = old {
+                let sig = self.signal;
+                thread::spawn(move || reap_child(old, sig));
+            }
+            self.broadcast(Event::Restarted);
+        } else {
+            // The new build wouldn't even start; keep the old child serving.
+            self.child = old;
         }
     }
 
     fn run(mut self) {
-        if self.build() {
-            self.spawn();
+        if self.build() && self.spawn() {
+            // Reload any browser sitting on the "starting up" page now that the
+            // app has come up for the first time.
+            self.broadcast(Event::Restarted);
         }
 
         loop {
@@ -508,11 +665,7 @@ impl Supervisor {
                 Ok(()) => {
                     self.broadcast(Event::Rebuild);
                     if self.build() {
-                        self.stop();
-                        self.spawn();
-                        if self.child.is_some() {
-                            self.broadcast(Event::Restarted);
-                        }
+                        self.hot_swap();
                     }
                     // On failure the old child keeps running; the browser shows
                     // the CompileError overlay until the next good build.
@@ -525,8 +678,7 @@ impl Supervisor {
                         log::warn!("app exited on its own; restarting");
                         self.child = None;
                         thread::sleep(Duration::from_millis(300)); // crash-loop backoff
-                        self.spawn();
-                        if self.child.is_some() {
+                        if self.spawn() {
                             self.broadcast(Event::Restarted);
                         }
                     }
@@ -537,21 +689,79 @@ impl Supervisor {
     }
 }
 
+/// Retire a child process, escalating if it won't leave. First `sig` (SIGTERM
+/// by default) asks trillium to drain in-flight connections and exit, and we
+/// give it a generous window. If it's still alive we send `sig` again —
+/// trillium treats a second SIGTERM as "exit hard, now" — and wait briefly.
+/// Only if even that is ignored do we STONITH with SIGKILL, on the assumption
+/// the process is asleep at the wheel and will never come back on its own.
+///
+/// Blocks for as long as the drain takes, so callers that need the new child
+/// serving meanwhile should run this on a background thread.
+fn reap_child(mut child: Child, sig: Signal) {
+    let pid = Pid::from_raw(child.id() as i32);
+    let graceful = Duration::from_secs(12);
+
+    // 1. Graceful: let trillium drain in-flight connections and shut down.
+    let _ = signal::kill(pid, sig);
+    if wait_for_exit(&mut child, graceful) {
+        log::info!("app exited gracefully after {sig}");
+        return;
+    }
+
+    // 2. Impatient: a second signal tells trillium to exit hard.
+    log::warn!(
+        "app still running {}s after {sig}; sending it again for a hard exit",
+        graceful.as_secs()
+    );
+    let _ = signal::kill(pid, sig);
+    if wait_for_exit(&mut child, Duration::from_millis(100)) {
+        log::info!("app exited after a second {sig}");
+        return;
+    }
+
+    // 3. STONITH: the process is wedged; there is no node, only the process.
+    log::warn!("app ignored two {sig} signals; sending SIGKILL");
+    let _ = signal::kill(pid, Signal::SIGKILL);
+    let _ = child.wait();
+}
+
+/// Poll `child` until it exits or `timeout` elapses. Returns true if it exited
+/// (and reaps it); false on timeout so the caller can escalate.
+fn wait_for_exit(child: &mut Child, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return true,
+            Ok(None) => {}
+            Err(e) => {
+                log::warn!("failed to check child status: {e}");
+                return false;
+            }
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
 /// Block until something is listening on `host:port`, or give up after 10s.
-fn wait_until_listening(host: &str, port: u16) {
+/// Returns true if we connected successfully, false if we timed out.
+fn wait_until_listening(host: &str, port: u16) -> bool {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
         if let Ok(addrs) = (host, port).to_socket_addrs() {
             for addr in addrs {
                 if TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok() {
                     log::info!("app is listening on {host}:{port}");
-                    return;
+                    return true;
                 }
             }
         }
         if Instant::now() >= deadline {
             log::warn!("app did not start listening on {host}:{port} within 10s");
-            return;
+            return false;
         }
         thread::sleep(Duration::from_millis(50));
     }
@@ -579,15 +789,50 @@ fn watch_loop(watches: Vec<PathBuf>, cwd: PathBuf, tx: mpsc::Sender<()>) {
     }
 
     loop {
-        if events_rx.recv().is_err() {
+        // Block for the first event of a burst.
+        let Ok(first) = events_rx.recv() else {
             return;
-        }
+        };
         // Coalesce a burst of events (one save touches many files) into a
-        // single rebuild by draining until things go quiet.
-        while events_rx.recv_timeout(Duration::from_millis(150)).is_ok() {}
+        // single rebuild by draining until things go quiet, collecting the
+        // paths that changed so we can report what actually triggered it.
+        let mut changed = BTreeSet::new();
+        record_changed(&mut changed, first, &cwd);
+        while let Ok(event) = events_rx.recv_timeout(Duration::from_millis(150)) {
+            record_changed(&mut changed, event, &cwd);
+        }
+
+        if changed.is_empty() {
+            log::info!("change detected; rebuilding");
+        } else {
+            let paths = changed
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            log::info!("change detected in {paths}; rebuilding");
+        }
+
         if tx.send(()).is_err() {
             return;
         }
+    }
+}
+
+/// Fold the paths from a notify event into `changed`, made relative to `cwd`
+/// when possible so the reported trigger is short and readable.
+fn record_changed(
+    changed: &mut BTreeSet<PathBuf>,
+    event: notify::Result<notify::Event>,
+    cwd: &Path,
+) {
+    let Ok(event) = event else { return };
+    for path in event.paths {
+        let path = path
+            .strip_prefix(cwd)
+            .map(Path::to_path_buf)
+            .unwrap_or(path);
+        changed.insert(path);
     }
 }
 
@@ -785,6 +1030,22 @@ fn cargo_metadata(cwd: &Path) -> Option<serde_json::Value> {
     serde_json::from_slice(&output.stdout).ok()
 }
 
+/// Split each shell-quoted `--build-args`/`--run-args` string into argv the way
+/// a shell would, flattening repeated occurrences into one list. Dies with a
+/// clear error (naming the flag) if a value has unbalanced quotes.
+fn shell_split(flag: &str, values: &[String]) -> Vec<String> {
+    let mut out = Vec::new();
+    for value in values {
+        match shlex::split(value) {
+            Some(tokens) => out.extend(tokens),
+            None => die(format!(
+                "could not parse `{flag} {value:?}` — unbalanced quotes?"
+            )),
+        }
+    }
+    out
+}
+
 /// Extract package names from `-p`/`--package` arguments forwarded to cargo.
 fn packages_from_args(args: &[String]) -> Vec<String> {
     let mut names = Vec::new();
@@ -810,7 +1071,7 @@ fn free_port() -> u16 {
         .unwrap_or_else(|e| die(format!("could not allocate a port: {e}")))
 }
 
-fn print_banner(server: &DevServer, upstream_port: u16, watches: &[PathBuf]) {
+fn print_banner(server: &DevServer, watches: &[PathBuf]) {
     let watches = watches
         .iter()
         .map(|w| w.display().to_string())
@@ -825,12 +1086,8 @@ fn print_banner(server: &DevServer, upstream_port: u16, watches: &[PathBuf]) {
         server.host,
         server.port
     );
-    println!(
-        "  {}    http://{}:{}",
-        "app".dimmed(),
-        server.app_host,
-        upstream_port
-    );
+    // The app's port isn't announced here: it rotates per rebuild, so each
+    // `app listening on …` line reports the real one as the service comes up.
     println!("  {}    {}", "watch".dimmed(), watches);
     println!();
 }
@@ -904,7 +1161,7 @@ mod proxy_app {
     use async_broadcast::Sender;
     use futures_lite::{StreamExt, future};
     use std::sync::{Arc, Mutex};
-    use trillium::{Conn, KnownHeaderName, State};
+    use trillium::{Conn, Handler, KnownHeaderName, State, Status};
     use trillium_client::Client;
     use trillium_html_rewriter::{
         HtmlRewriter,
@@ -914,6 +1171,77 @@ mod proxy_app {
     use trillium_router::Router;
     use trillium_smol::ClientConfig;
     use trillium_websockets::{Message, WebSocket, WebSocketConn};
+
+    /// Served in place of the proxy's BadGateway while the app isn't up yet. The
+    /// live-reload script is injected into `<body>` by the HtmlRewriter (not
+    /// baked in here), so the page reloads itself the moment the app is ready.
+    const STARTING_UP_PAGE: &str = r#"<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>starting up…</title>
+<style>
+  html, body { height: 100%; margin: 0; }
+  body {
+    display: flex; align-items: center; justify-content: center;
+    background: #1e1e2e; color: #cdd6f4;
+    font: 15px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .box { text-align: center; padding: 32px; }
+  .spin {
+    width: 28px; height: 28px; margin: 0 auto 20px;
+    border: 3px solid #45475a; border-top-color: #a6e3a1;
+    border-radius: 50%; animation: spin .8s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  h1 { font-size: 16px; font-weight: 600; margin: 0 0 8px; color: #a6e3a1; }
+  p { margin: 0; color: #6c7086; font-size: 13px; }
+</style>
+</head>
+<body>
+  <div class="box">
+    <div class="spin"></div>
+    <h1>starting your trillium app…</h1>
+    <p>the first build can take a moment — this page reloads automatically.</p>
+  </div>
+</body>
+</html>"#;
+
+    /// Serves the "starting up" page whenever there's no live app to reach:
+    /// either the first build hasn't come up yet (upstream port still 0, so the
+    /// proxy passes the conn through untouched — status `None`), or the app is
+    /// momentarily unreachable during a crash/restart (proxy sets `BadGateway`).
+    /// Both get an honest `503 Service Unavailable` with a readable body; a real
+    /// status from the running app (a 500, a 404, anything) passes through.
+    ///
+    /// This runs in `before_send` rather than `run` because the proxy halts the
+    /// conn on the BadGateway path, which skips the rest of the `run` chain;
+    /// `before_send` fires on every handler regardless of halt.
+    struct StartingUpPage {
+        upstream: super::DynamicUpstream,
+    }
+
+    impl Handler for StartingUpPage {
+        async fn run(&self, conn: Conn) -> Conn {
+            conn
+        }
+
+        async fn before_send(&self, conn: Conn) -> Conn {
+            // A reachable app that answered for itself: leave it alone.
+            if self.upstream.is_ready() && conn.status() != Some(Status::BadGateway) {
+                return conn;
+            }
+            log::debug!(
+                "no app to reach (status={:?}, upstream_ready={}); serving starting-up page",
+                conn.status(),
+                self.upstream.is_ready()
+            );
+            conn.with_status(Status::ServiceUnavailable)
+                .with_response_header(KnownHeaderName::ContentType, "text/html; charset=utf-8")
+                .with_body(STARTING_UP_PAGE)
+        }
+    }
 
     /// Per-connection state for the live-reload websocket.
     #[derive(Clone)]
@@ -935,7 +1263,7 @@ mod proxy_app {
     pub fn run(
         host: String,
         port: u16,
-        upstream: String,
+        upstream: super::DynamicUpstream,
         events: Sender<Event>,
         editor: Option<String>,
         open_targets: Arc<Mutex<Vec<EditorTarget>>>,
@@ -967,7 +1295,10 @@ mod proxy_app {
                         "/_dev_server.ws",
                         (State::new(state), WebSocket::new(live_reload)),
                     ),
-                Proxy::new(client, &*upstream),
+                Proxy::new(client, upstream.clone()),
+                // Injects the live-reload client into the <body> of any HTML
+                // response — the proxied app *and* the starting-up page — so the
+                // latter reloads itself once the app is listening.
                 HtmlRewriter::new(|| {
                     Settings::new_send().append_element_content_handler(element!("body", |el| {
                         el.append(
@@ -977,6 +1308,10 @@ mod proxy_app {
                         Ok(())
                     }))
                 }),
+                // Last in the tuple so its `before_send` runs *first* (before_send
+                // fires right-to-left), letting it swap in the starting-up page
+                // before the rewriter above injects the reload client into it.
+                StartingUpPage { upstream },
             ));
     }
 


### PR DESCRIPTION
* switch ports between reloads
* better trillium-specific graceful shutdown behavior
* zero-downtime switches
* send build output to stderr
* switch from -- {build args} to --build-args and --run-args
* add a starting-up page